### PR TITLE
Add a way to cleanly shut down the library

### DIFF
--- a/git.go
+++ b/git.go
@@ -139,6 +139,16 @@ func init() {
 	C.git_openssl_set_locking()
 }
 
+// Shutdown frees all the resources acquired by libgit2. Make sure no
+// references to any git2go objects are live before calling this.
+// After this is called, invoking any function from this library will result in
+// undefined behavior, so make sure this is called carefully.
+func Shutdown() {
+	pointerHandles.Clear()
+
+	C.git_libgit2_shutdown()
+}
+
 // Oid represents the id for a Git object.
 type Oid [20]byte
 

--- a/handles.go
+++ b/handles.go
@@ -43,6 +43,16 @@ func (v *HandleList) Untrack(handle unsafe.Pointer) {
 	v.Unlock()
 }
 
+// Clear stops tracking all the managed pointers.
+func (v *HandleList) Clear() {
+	v.Lock()
+	for handle := range v.handles {
+		delete(v.handles, handle)
+		C.free(handle)
+	}
+	v.Unlock()
+}
+
 // Get retrieves the pointer from the given handle
 func (v *HandleList) Get(handle unsafe.Pointer) interface{} {
 	v.RLock()


### PR DESCRIPTION
This change adds the Shutdown() method, so that the library can be
cleanly shut down. This helps significanly reduce the amount of noise in
the leak detector.